### PR TITLE
Hourly Worker Support

### DIFF
--- a/hrflow/work_log.go
+++ b/hrflow/work_log.go
@@ -26,12 +26,12 @@ type WorkLogRow struct {
 	MainSalaryFactorID int64 `json:"mainSalaryFactorId"`
 	// mainAmount is the number of hours that should be reported as a string.
 	MainAmount string `json:"mainAmount"`
-	// mainUnit is always DURATION (the default?).
+	// mainUnit is DURATION for monthly workers, and HOURS for hourly workers.
 	MainUnit       string          `json:"mainUnit"`
 	WorkLogFactors []WorkLogFactor `json:"workLogFactors"`
-
-	StartTime        string `json:"startTime"`
-	EndTime          string `json:"endTime"`
+	StartTime      string          `json:"startTime"`
+	EndTime        string          `json:"endTime"`
+	// 99002 for DURATION (monthly workers), 11000 for HOURS (hourly workers)
 	SalaryGroupValue string `json:"salaryGroupValue"`
 	// status is NEW if being created.
 	Status string `json:"status"`

--- a/hrflow/work_log.go
+++ b/hrflow/work_log.go
@@ -224,7 +224,7 @@ type newWorkLogResponse struct {
 	ActionSuccessful bool `json:"actionSuccessful,omitempty"`
 }
 
-func (c *Client) NewWorkLog(startTime, endTime time.Time, salaryGroupValue string, comment string, project *string) error {
+func (c *Client) NewWorkLog(startTime, endTime time.Time, salaryGroupValue string, comment string, project *string, lunch bool) error {
 
 	if len(c.Employments) == 0 {
 		return errors.New("no employment found, cannot log hours")
@@ -234,6 +234,10 @@ func (c *Client) NewWorkLog(startTime, endTime time.Time, salaryGroupValue strin
 
 	// Salary group is always the same, but probably shouldn't be hardcoded. No good way to get it right now.
 	row := c.NewWorkLogRow(employment.EmploymentID, employment.PersonID, employment.GroupID, startTime, endTime, salaryGroupValue, comment, project)
+	if !lunch {
+		row.LunchBreak = 0
+		row.CutLunchFromAmount = "N"
+	}
 	rowJSON, err := json.Marshal(row)
 	if err != nil {
 		return errors.Wrap(err, "marshaling work log row")

--- a/hrflow/work_log.go
+++ b/hrflow/work_log.go
@@ -224,7 +224,7 @@ type newWorkLogResponse struct {
 	ActionSuccessful bool `json:"actionSuccessful,omitempty"`
 }
 
-func (c *Client) NewWorkLog(startTime, endTime time.Time, comment string, project *string) error {
+func (c *Client) NewWorkLog(startTime, endTime time.Time, salaryGroupValue string, comment string, project *string) error {
 
 	if len(c.Employments) == 0 {
 		return errors.New("no employment found, cannot log hours")
@@ -233,7 +233,7 @@ func (c *Client) NewWorkLog(startTime, endTime time.Time, comment string, projec
 	employment := c.Employments[0]
 
 	// Salary group is always the same, but probably shouldn't be hardcoded. No good way to get it right now.
-	row := c.NewWorkLogRow(employment.EmploymentID, employment.PersonID, employment.GroupID, startTime, endTime, "99002", comment, project)
+	row := c.NewWorkLogRow(employment.EmploymentID, employment.PersonID, employment.GroupID, startTime, endTime, salaryGroupValue, comment, project)
 	rowJSON, err := json.Marshal(row)
 	if err != nil {
 		return errors.Wrap(err, "marshaling work log row")

--- a/main.go
+++ b/main.go
@@ -56,6 +56,11 @@ func main() {
 						Usage:       "`DATE` for the report, format 'd.M.' (years not supported)",
 						DefaultText: "today",
 					},
+					&cli.BoolFlag{
+						Name:  "hourly",
+						Value: false,
+						Usage: "Report units as an hourly worker, also won't include 30 minute lunch in the duration.",
+					},
 				},
 				Action: report,
 			},

--- a/report.go
+++ b/report.go
@@ -59,6 +59,9 @@ func report(c *cli.Context) error {
 		project = &p
 	}
 
+	// Lunch is only applicable for monthly workers.
+	lunch := !hourly
+
 	client, err := clientFromConfig()
 	if err != nil {
 		return errors.Wrap(err, "creating client from config")
@@ -68,7 +71,7 @@ func report(c *cli.Context) error {
 		return errors.Wrap(err, "authentication failed")
 	}
 
-	err = client.NewWorkLog(*start, *end, salaryGroupValue, comment, project)
+	err = client.NewWorkLog(*start, *end, salaryGroupValue, comment, project, lunch)
 	if err != nil {
 		return errors.Wrap(err, "creating work log")
 	}

--- a/report.go
+++ b/report.go
@@ -44,6 +44,14 @@ func report(c *cli.Context) error {
 		start = &t
 	}
 
+	hourly := c.Bool("hourly")
+	var salaryGroupValue string
+	if hourly {
+		salaryGroupValue = "11000"
+	} else {
+		salaryGroupValue = "99002"
+	}
+
 	comment := c.String("comment")
 	p := c.String("project")
 	var project *string
@@ -60,7 +68,7 @@ func report(c *cli.Context) error {
 		return errors.Wrap(err, "authentication failed")
 	}
 
-	err = client.NewWorkLog(*start, *end, comment, project)
+	err = client.NewWorkLog(*start, *end, salaryGroupValue, comment, project)
 	if err != nil {
 		return errors.Wrap(err, "creating work log")
 	}


### PR DESCRIPTION
Doing the reporting as an hourly worker can now be done with the `--hourly` flag.